### PR TITLE
Fix full-width spaces to half-width spaces

### DIFF
--- a/config/properties.json
+++ b/config/properties.json
@@ -94,7 +94,7 @@
       {
         "propertyId": "gene_high_level_expression_gtex6",
         "label": "Expressed in tissues",
-        "description": "Tissues in which a gene is tissue-specific highly expressed in 49 tissues of GTEx　V6",
+        "description": "Tissues in which a gene is tissue-specific highly expressed in 49 tissues of GTEx V6",
         "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_gtex6",
         "dataSource": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
         "dataSourceUrl": "https://doi.org/10.1101/311563",
@@ -106,7 +106,7 @@
       {
         "propertyId": "gene_not_expressed_in_tissue_gtex",
         "label": "Not expressed in tissues",
-        "description": "Tissues in which expression of a gene is not detected in 53 tissues of GTEx　V8",
+        "description": "Tissues in which expression of a gene is not detected in 53 tissues of GTEx V8",
         "data": "https://integbio.jp/togosite/sparqlist/api/gene_not_expressed_in_tissues_gtex",
         "dataSource": "GTEx",
         "dataSourceUrl": "https://gtexportal.org/home/datasets",


### PR DESCRIPTION
markdownでは全角に見えないのに、TogoDXのDescriptionでは全角に見えていた(謎)GTExのバージョン表記部分を修正。