### PR TITLE
Fix labels & desc for "Specifically expressed" bars

### DIFF
--- a/config/properties.json
+++ b/config/properties.json
@@ -56,8 +56,8 @@
       },
       {
         "propertyId": "gene_high_level_expression_refex",
-        "label": "High-level expression",
-        "description": "Tissues in which a gene was tissue-specific highly expressed only in one of 34 tissues of RefEx",
+        "label": "Specifically expressed in tissues (RefEx)",
+        "description": "Tissues in which a gene was tissue-specific highly expressed in 34 tissues of RefEx(GeneChip microarray)",
         "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_refex",
         "dataSource": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
         "dataSourceUrl": "https://doi.org/10.6084/m9.figshare.4028700.v3",
@@ -68,8 +68,8 @@
       },
       {
         "propertyId": "gene_low_level_expression_refex",
-        "label": "Low-level expression",
-        "description": "Tissues in which a gene was tissue-specific lowly expressed only in one of 34 tissues of RefEx",
+        "label": "Specifically low-expressed in tissues (RefEx)",
+        "description": "Tissues in which a gene was tissue-specific lowly expressed in 34 tissues of RefEx(GeneChip microarray)",
         "data": "https://integbio.jp/togosite/sparqlist/api/gene_low_level_expression_refex",
         "dataSource": "Calculations for tissue specificity of genechip human GSE7307 from RefEx",
         "dataSourceUrl": "https://doi.org/10.6084/m9.figshare.4028700.v3",
@@ -80,7 +80,7 @@
       },
       {
         "propertyId": "gene_high_level_expression_gtex6",
-        "label": "Expressed in tissues",
+        "label": "Specifically expressed in tissues (GTEx)",
         "description": "Tissues in which a gene is tissue-specific highly expressed in 49 tissues of GTEx V6",
         "data": "https://integbio.jp/togosite/sparqlist/api/gene_high_level_expression_gtex6",
         "dataSource": "Supplementary Table 1 of A systematic survey of human tissue-specific gene expression and splicing reveals new opportunities for therapeutic target identification and evaluation; R. Y. Yang et al.; bioRxiv 311563",
@@ -92,7 +92,7 @@
       },
       {
         "propertyId": "gene_not_expressed_in_tissues_gtex",
-        "label": "Not expressed in tissues",
+        "label": "Not expressed in tissues (GTEx)",
         "description": "Tissues in which expression of a gene is not detected in 53 tissues of GTEx V8",
         "data": "https://integbio.jp/togosite/sparqlist/api/gene_not_expressed_in_tissues_gtex",
         "dataSource": "GTEx",
@@ -104,7 +104,7 @@
       },
       {
         "propertyId": "gene_specific_expression_in_tissues_hpa",
-        "label": "Specifically expressed in tissues",
+        "label": "Specifically expressed in tissues (HPA)",
         "description": "Tissues in which expression specificity of a gene is evaluated as \"Tissue enriched\", \"Tissue enhanced\", or\"Group enriched\" by Human Protein Atlas",
         "data": "https://integbio.jp/togosite/sparqlist/api/gene_specific_expression_in_tissues_hpa",
         "dataSource": "HPA TSV",
@@ -116,7 +116,7 @@
       },
       {
         "propertyId": "gene_specific_expression_in_cells_hpa",
-        "label": "Specifically expressed in cell types",
+        "label": "Specifically expressed in cell types (HPA)",
         "description": "Cell types in which expression specificity of a gene is evaluated as \"Cell type enriched\", \"Cell type enhanced\", or\"Group enriched\" by Human Protein Atlas",
         "data": "https://integbio.jp/togosite/sparqlist/api/gene_specific_expression_in_cells_hpa",
         "dataSource": "HPA TSV",


### PR DESCRIPTION
遺伝子カテゴリの特異的発現のバーのラベルの表現を統一しました。例外的に、識別に重要になるDB名をラベル名に入れています。
またRefExのバーのDescが間違っていたのを修正しました。