### PR TITLE
updated glytoucan example IDs

### DIFF
--- a/config/attributes.json
+++ b/config/attributes.json
@@ -1185,10 +1185,11 @@
       "template": "https://raw.githubusercontent.com/togodx/togodx-config-human/develop/templates/glytoucan.hbs",
       "target": true,
       "examples": [
-        "G88006IV",
-        "G53085MI",
-        "G17896UT",
-        "G50341PG"
+        "G00035MO",
+        "G29011JC",
+        "G20030CU",
+        "G00033MO",
+        "G39213VZ"
       ],
       "conversion": {
         "chebi": "https://api.togoid.dbcls.jp/convert?format=json&route=glytoucan,pubchem_compound,chebi&ids=",

--- a/config/attributes.server.json
+++ b/config/attributes.server.json
@@ -1185,10 +1185,11 @@
       "template": "https://raw.githubusercontent.com/togodx/togodx-config-human/develop/templates/glytoucan.hbs",
       "target": true,
       "examples": [
-        "G88006IV",
-        "G53085MI",
-        "G17896UT",
-        "G50341PG"
+        "G00035MO",
+        "G29011JC",
+        "G20030CU",
+        "G00033MO",
+        "G39213VZ"
       ],
       "conversion": {
         "chebi": "https://api.togoid.dbcls.jp/convert?format=json&route=glytoucan,pubchem_compound,chebi&ids=",


### PR DESCRIPTION
GlyTouCan の Example ID を変えました。
doid, pubchem compound, uniprot のいずれにもつながる ID を選んでいます。