### PR TITLE
Fix hbs

### DIFF
--- a/templates/chembl_compound.hbs
+++ b/templates/chembl_compound.hbs
@@ -7,7 +7,7 @@
       data-url="https://integbio.jp/togosite/sparqlist/api/metastanza_chembl_compound?id={{id}}"
       data-type="json"
       format-key="true"
-      columns="[{&quot;id&quot;:&quot;ID&quot;,&quot;link&quot;:&quot;URL&quot;},{&quot;id&quot;:&quot;label&quot;,&quot;escape&quot;:false},{&quot;id&quot;:&quot;molecular_formula&quot;},{&quot;id&quot;:&quot;molecular_weight&quot;},{&quot;id&quot;:&quot;type&quot;},{&quot;id&quot;:&quot;SMILES&quot;},{&quot;id&quot;:&quot;InChI&quot;}]"
+      columns="[{&quot;id&quot;:&quot;ID&quot;,&quot;link&quot;:&quot;URL&quot;},{&quot;id&quot;:&quot;label&quot;},{&quot;id&quot;:&quot;synonyms&quot;,&quot;escape&quot;:false},{&quot;id&quot;:&quot;molecular_formula&quot;},{&quot;id&quot;:&quot;molecular_weight&quot;},{&quot;id&quot;:&quot;type&quot;},{&quot;id&quot;:&quot;SMILES&quot;},{&quot;id&quot;:&quot;InChI&quot;}]"
       custom-css-url="css/stanza.css"
     />
   </section>

--- a/templates/togovar.hbs
+++ b/templates/togovar.hbs
@@ -9,7 +9,7 @@
       width="800"
       height="400"
       padding="0"
-      columns=""
+      columns="[{&quot;id&quot;: &quot;tgv_id&quot;, &quot;label&quot;: &quot;TogoVar ID&quot;, &quot;link&quot;: &quot;url&quot;}, {&quot;id&quot;: &quot;type_label&quot;, &quot;label&quot;: &quot;Variant type&quot;}, {&quot;id&quot;: &quot;hgvs&quot;, &quot;label&quot;: &quot;HGVS&quot;}]"
       format-key="true"
       custom-css-url="css/stanza.css"
     />


### PR DESCRIPTION
- ChEMBL compound で、Label という項目名で表示するものが skos:altLabel になっていたので、Label には rdfs:label だけを表示するようにし、altLabel は Synonyms という項目名で出すように変更。
- TogoVar の ID を clickable リンクに変更。